### PR TITLE
Better error handling and print warning when Image format not registered

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,5 +1,11 @@
 name: Static Analysis
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**'
 concurrency:
   group: static-analysis-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '>=1.19.0'
+        go-version: '~1.19.0'
     - name: Get dependencies
       run: |
         go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: '>=1.20.0'
     - name: Get dependencies
       run: |
         go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '>=1.20.0'
+        go-version: '>=1.19.0'
     - name: Get dependencies
       run: |
         go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: '>=1.20.0'
     - name: Get dependencies
       run: |
         go get github.com/onsi/ginkgo/v2/ginkgo

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
         go-version: '>=1.20.0'
     - name: Get dependencies
       run: |
-        go get github.com/onsi/ginkgo/v2/ginkgo
-        go get github.com/onsi/gomega/...
+        go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+        go install github.com/onsi/gomega/...
     - name: Run tests
       run: |
         ginkgo -r ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '>=1.19.0'
+        go-version: '~1.19.0'
     - name: Get dependencies
       run: |
         go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '>=1.20.0'
+        go-version: '>=1.19.0'
     - name: Get dependencies
       run: |
         go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,11 @@
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**'
 concurrency:
   group: tests-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true

--- a/pairing.go
+++ b/pairing.go
@@ -15,7 +15,7 @@ import (
 	node "github.com/mudler/edgevpn/pkg/node"
 )
 
-func newNode(cfg *PairConfig) *node.Node {
+func newNode(cfg *PairConfig) (*node.Node, error) {
 	llger := logger.New(log.LevelFatal)
 	defaultInterval := 10 * time.Second
 
@@ -60,16 +60,16 @@ func newNode(cfg *PairConfig) *node.Node {
 
 	nodeOpts, _, err := c.ToOpts(llger)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("parsing options: %w", err)
 	}
 
 	nodeOpts = append(nodeOpts, services.Alive(30*time.Second, 900*time.Second, 15*time.Minute)...)
 
 	n, err := node.New(nodeOpts...)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("creating a new node: %w", err)
 	}
-	return n
+	return n, nil
 }
 
 // TokenReader is a function that reads a string and returns a token from it.
@@ -147,7 +147,10 @@ func Receive(ctx context.Context, payload interface{}, opts ...PairOption) error
 		return err
 	}
 
-	n := newNode(c)
+	n, err := newNode(c)
+	if err != nil {
+		return err
+	}
 
 	if err := n.Start(ctx); err != nil {
 		return err
@@ -229,7 +232,10 @@ func Send(ctx context.Context, payload interface{}, opts ...PairOption) error {
 		return err
 	}
 
-	n := newNode(c)
+	n, err := newNode(c)
+	if err != nil {
+		return err
+	}
 
 	n.Start(ctx)
 

--- a/qrcode/qrcode.go
+++ b/qrcode/qrcode.go
@@ -45,6 +45,9 @@ func FromScreenshot() (string, error) {
 		if err == nil && text != "" {
 			return text, err
 		}
+		if err != nil {
+			return "", err
+		}
 	}
 
 	return "", errors.New("nothing found")
@@ -100,7 +103,10 @@ func Reader(s string) (res string) {
 	if s == "" {
 		res, _ = FromScreenshot()
 	} else {
-		r, _ := Scan(s)
+		r, err := Scan(s)
+		if err != nil {
+			fmt.Printf("warning: %s\n", err.Error())
+		}
 		if r != "" {
 			res = r
 		} else {


### PR DESCRIPTION
For example for a ppm image, a call like this is needed before `Decode` is called:

```
image.RegisterFormat("ppm", "ppm", ppm.Decode, ppm.DecodeConfig)
```

Failing to do so, will silently hide the problem resulting in a strange error on the provider side:

```
illegal base64 data at input byte 9
```